### PR TITLE
Feat #25 : Statistics API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-
-## todo : application.yml 바꾸기, 삭제할 예정입니다.
-src/main/resources/application.yml

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+## todo : application.yml 바꾸기, 삭제할 예정입니다.
+src/main/resources/application.yml

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/controller/StatisticsController.java
@@ -34,6 +34,7 @@ public class StatisticsController {
             @RequestParam(required = false) Date start,
             @RequestParam(required = false) Date end,
             @RequestParam(required = false) String value) {
+        System.out.println("controller");
         return statisticsService.getStatistics();
     }
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/controller/StatisticsController.java
@@ -3,6 +3,8 @@ package com.example.socialmediafeed.domain.statistics.controller;
 import com.example.socialmediafeed.domain.statistics.dto.StatisticsResponseDto;
 import com.example.socialmediafeed.domain.statistics.service.StatisticsService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -26,13 +28,13 @@ public class StatisticsController {
      * @return List<StatisticsResponseDto>
      */
     @GetMapping
-    @ResponseBody // todo : ResponseEntity로 변경
-    public List<StatisticsResponseDto> getStatistics(
+    @ResponseBody
+    public ResponseEntity getStatistics(
             @RequestParam(required = false) String hashtag,
             @RequestParam String type, // date, hour 둘 중 하나
             @RequestParam(required = false) String start,
             @RequestParam(required = false) String end,
             @RequestParam(required = false) String value) {
-        return statisticsService.getStatistics(hashtag, start, end, type, value);
+        return new ResponseEntity<>(statisticsService.getStatistics(hashtag, start, end, type, value), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/controller/StatisticsController.java
@@ -28,13 +28,12 @@ public class StatisticsController {
      * @return List<StatisticsResponseDto>
      */
     @GetMapping
-    @ResponseBody
     public ResponseEntity getStatistics(
             @RequestParam(required = false) String hashtag,
             @RequestParam String type, // date, hour 둘 중 하나
             @RequestParam(required = false) String start,
             @RequestParam(required = false) String end,
             @RequestParam(required = false) String value) {
-        return new ResponseEntity<>(statisticsService.getStatistics(hashtag, start, end, type, value), HttpStatus.OK);
+        return ResponseEntity.status(HttpStatus.OK).body(statisticsService.getStatistics(hashtag, start, end, type, value));
     }
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/controller/StatisticsController.java
@@ -3,10 +3,8 @@ package com.example.socialmediafeed.domain.statistics.controller;
 import com.example.socialmediafeed.domain.statistics.dto.StatisticsResponseDto;
 import com.example.socialmediafeed.domain.statistics.service.StatisticsService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Date;
 import java.util.List;
 
 /// 통계 관련 API
@@ -19,6 +17,7 @@ public class StatisticsController {
 
     /**
      * 통계 반환 메서드
+     *
      * @param hashtag
      * @param type
      * @param start
@@ -28,13 +27,12 @@ public class StatisticsController {
      */
     @GetMapping
     @ResponseBody // todo : ResponseEntity로 변경
-    public List<StatisticsResponseDto> getStatistics (
+    public List<StatisticsResponseDto> getStatistics(
             @RequestParam(required = false) String hashtag,
             @RequestParam String type, // date, hour 둘 중 하나
-            @RequestParam(required = false) Date start,
-            @RequestParam(required = false) Date end,
+            @RequestParam(required = false) String start,
+            @RequestParam(required = false) String end,
             @RequestParam(required = false) String value) {
-        System.out.println("controller");
-        return statisticsService.getStatistics();
+        return statisticsService.getStatistics(hashtag, start, end, type, value);
     }
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/dto/StatisticsResponseDto.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/dto/StatisticsResponseDto.java
@@ -13,5 +13,5 @@ import java.time.LocalDateTime;
 public class StatisticsResponseDto {
 
     public LocalDateTime time;
-    public int count;
+    public Integer count;
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepository.java
@@ -1,0 +1,9 @@
+package com.example.socialmediafeed.domain.statistics.repository;
+
+import com.example.socialmediafeed.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatisticsRepository extends JpaRepository<Post, Long>, StatisticsRepositoryCustom {
+
+
+}

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryCustom.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryCustom.java
@@ -1,15 +1,14 @@
 package com.example.socialmediafeed.domain.statistics.repository;
 
-import com.example.socialmediafeed.domain.post.entity.Post;
 import com.example.socialmediafeed.domain.statistics.dto.StatisticsResponseDto;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public interface StatisticsRepositoryCustom {
 
-    // QueryDsl 사용 예시 todo : 예시를 위한 것으로, 지울 예정임
-    Post findByIdCustom(Long id);
-
     // 날짜별로 Like_Count의 합계를 반환함
-    List<StatisticsResponseDto> DateLikeCount();
+    List<StatisticsResponseDto> getStatistics(String hashtag, Map<LocalDateTime, LocalDateTime> dateTimeMap, String value);
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryCustom.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryCustom.java
@@ -1,9 +1,15 @@
 package com.example.socialmediafeed.domain.statistics.repository;
 
 import com.example.socialmediafeed.domain.post.entity.Post;
+import com.example.socialmediafeed.domain.statistics.dto.StatisticsResponseDto;
+
+import java.util.List;
 
 public interface StatisticsRepositoryCustom {
 
     // QueryDsl 사용 예시 todo : 예시를 위한 것으로, 지울 예정임
     Post findByIdCustom(Long id);
+
+    // 날짜별로 Like_Count의 합계를 반환함
+    List<StatisticsResponseDto> DateLikeCount();
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryCustom.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.example.socialmediafeed.domain.statistics.repository;
+
+import com.example.socialmediafeed.domain.post.entity.Post;
+
+public interface StatisticsRepositoryCustom {
+
+    // QueryDsl 사용 예시 todo : 예시를 위한 것으로, 지울 예정임
+    Post findByIdCustom(Long id);
+}

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryCustom.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryCustom.java
@@ -9,6 +9,5 @@ import java.util.Map;
 
 public interface StatisticsRepositoryCustom {
 
-    // 날짜별로 Like_Count의 합계를 반환함
     List<StatisticsResponseDto> getStatistics(String hashtag, Map<LocalDateTime, LocalDateTime> dateTimeMap, String value);
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
@@ -1,8 +1,17 @@
 package com.example.socialmediafeed.domain.statistics.repository;
 
 import com.example.socialmediafeed.domain.post.entity.Post;
+import com.example.socialmediafeed.domain.statistics.dto.StatisticsResponseDto;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 import static com.example.socialmediafeed.domain.post.entity.QPost.post;
 
@@ -19,4 +28,39 @@ public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom{
                 .where(post.id.eq(id))
                 .fetchFirst();
     }
+
+    @Override
+    public List<StatisticsResponseDto> DateLikeCount() {
+        System.out.println("repository");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss");
+        List<LocalDateTime> dateTimeList = new ArrayList<>();
+        List<StatisticsResponseDto> statisticsResponseDtoList = new ArrayList<>();
+        try{
+            // for문 돌릴 date List
+            LocalDateTime date1 = LocalDateTime.parse("2023-10-29-00-00-00", formatter);
+            LocalDateTime date2 = LocalDateTime.parse("2023-10-29-00-00-00", formatter);
+            dateTimeList.add(date1);
+            dateTimeList.add(date2);
+
+            for(LocalDateTime dateTime : dateTimeList) {
+                System.out.println("dateTime1");
+                LocalDateTime start = LocalDateTime.of(2023, 10,29,0,0,0);
+                LocalDateTime end = LocalDateTime.of(2023,10,29,23,59,59);
+                int dateCount = queryFactory
+                        .select(post.likeCount.sum())
+                        .from(post)
+                        .where(post.createdAt.between(start, end))
+                        .fetchFirst();
+                statisticsResponseDtoList.add(StatisticsResponseDto.builder()
+                        .time(dateTime)
+                        .count(dateCount)
+                        .build());
+            }
+        } catch (Exception e) {
+            //hello
+        }
+        return statisticsResponseDtoList;
+    }
+
+
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
@@ -1,0 +1,22 @@
+package com.example.socialmediafeed.domain.statistics.repository;
+
+import com.example.socialmediafeed.domain.post.entity.Post;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.example.socialmediafeed.domain.post.entity.QPost.post;
+
+@RequiredArgsConstructor
+public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+
+
+    // QueryDsl 사용 예시 todo : 예시를 위한 것으로, 지울 예정임
+    @Override
+    public Post findByIdCustom(Long id) {
+        return queryFactory
+                .selectFrom(post)
+                .where(post.id.eq(id))
+                .fetchFirst();
+    }
+}

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.example.socialmediafeed.domain.post.entity.QPost.post;
+import static com.example.socialmediafeed.domain.posthashtag.entity.QPostHashtag.postHashtag;
 
 @RequiredArgsConstructor
 public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
@@ -29,6 +30,7 @@ public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
                 dateCount = queryFactory
                         .select(post.viewCount.sum())
                         .from(post)
+                        .join(postHashtag).on(postHashtag.hashtag.name.eq(hashtag), post.id.eq(postHashtag.post.id))
                         .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
                         .fetchFirst();
             }
@@ -38,6 +40,7 @@ public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
                 dateCount = queryFactory
                         .select(post.likeCount.sum())
                         .from(post)
+                        .join(postHashtag).on(postHashtag.hashtag.name.eq(hashtag), post.id.eq(postHashtag.post.id))
                         .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
                         .fetchFirst();
             }
@@ -47,6 +50,7 @@ public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
                 dateCount = queryFactory
                         .select(post.shareCount.sum())
                         .from(post)
+                        .join(postHashtag).on(postHashtag.hashtag.name.eq(hashtag), post.id.eq(postHashtag.post.id))
                         .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
                         .fetchFirst();
             }
@@ -56,6 +60,7 @@ public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
                 dateCount = Math.toIntExact(queryFactory
                         .select(post.count())
                         .from(post)
+                        .join(postHashtag).on(postHashtag.hashtag.name.eq(hashtag), post.id.eq(postHashtag.post.id))
                         .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
                         .fetchFirst());
             }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
@@ -1,66 +1,59 @@
 package com.example.socialmediafeed.domain.statistics.repository;
 
-import com.example.socialmediafeed.domain.post.entity.Post;
 import com.example.socialmediafeed.domain.statistics.dto.StatisticsResponseDto;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import static com.example.socialmediafeed.domain.post.entity.QPost.post;
 
 @RequiredArgsConstructor
-public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom{
+public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
-
-    // QueryDsl 사용 예시 todo : 예시를 위한 것으로, 지울 예정임
     @Override
-    public Post findByIdCustom(Long id) {
-        return queryFactory
-                .selectFrom(post)
-                .where(post.id.eq(id))
-                .fetchFirst();
-    }
-
-    @Override
-    public List<StatisticsResponseDto> DateLikeCount() {
-        System.out.println("repository");
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm-ss");
-        List<LocalDateTime> dateTimeList = new ArrayList<>();
+    public List<StatisticsResponseDto> getStatistics(String hashtag, Map<LocalDateTime, LocalDateTime> dateTimeMap, String value) {
         List<StatisticsResponseDto> statisticsResponseDtoList = new ArrayList<>();
-        try{
-            // for문 돌릴 date List
-            LocalDateTime date1 = LocalDateTime.parse("2023-10-29-00-00-00", formatter);
-            LocalDateTime date2 = LocalDateTime.parse("2023-10-29-00-00-00", formatter);
-            dateTimeList.add(date1);
-            dateTimeList.add(date2);
+        for (Map.Entry<LocalDateTime, LocalDateTime> dateTime : dateTimeMap.entrySet()) {
 
-            for(LocalDateTime dateTime : dateTimeList) {
-                System.out.println("dateTime1");
-                LocalDateTime start = LocalDateTime.of(2023, 10,29,0,0,0);
-                LocalDateTime end = LocalDateTime.of(2023,10,29,23,59,59);
-                int dateCount = queryFactory
+            // 좋아요, 조회수, 공유수, 게시글 수 기준으로 조회하기 //
+            Integer dateCount = 0;
+            if (Objects.equals(value, "view_count")) {
+                dateCount = queryFactory
+                        .select(post.viewCount.sum())
+                        .from(post)
+                        .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
+                        .fetchFirst();
+            } else if (Objects.equals(value, "like_count")) {
+                dateCount = queryFactory
                         .select(post.likeCount.sum())
                         .from(post)
-                        .where(post.createdAt.between(start, end))
+                        .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
                         .fetchFirst();
-                statisticsResponseDtoList.add(StatisticsResponseDto.builder()
-                        .time(dateTime)
-                        .count(dateCount)
-                        .build());
+            } else if (Objects.equals(value, "share_count")) {
+                dateCount = queryFactory
+                        .select(post.shareCount.sum())
+                        .from(post)
+                        .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
+                        .fetchFirst();
+            } else {
+                dateCount = Math.toIntExact(queryFactory
+                        .select(post.count())
+                        .from(post)
+                        .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
+                        .fetchFirst());
             }
-        } catch (Exception e) {
-            //hello
+
+            statisticsResponseDtoList.add(StatisticsResponseDto.builder()
+                    .time(dateTime.getKey())
+                    .count(dateCount == null ? 0 : dateCount)
+                    .build());
         }
         return statisticsResponseDtoList;
     }
-
-
 }

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/repository/StatisticsRepositoryImpl.java
@@ -18,30 +18,41 @@ public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
 
     @Override
     public List<StatisticsResponseDto> getStatistics(String hashtag, Map<LocalDateTime, LocalDateTime> dateTimeMap, String value) {
-        List<StatisticsResponseDto> statisticsResponseDtoList = new ArrayList<>();
-        for (Map.Entry<LocalDateTime, LocalDateTime> dateTime : dateTimeMap.entrySet()) {
 
-            // 좋아요, 조회수, 공유수, 게시글 수 기준으로 조회하기 //
+        List<StatisticsResponseDto> statisticsResponseDtoList = new ArrayList<>();
+
+        for (Map.Entry<LocalDateTime, LocalDateTime> dateTime : dateTimeMap.entrySet()) {
             Integer dateCount = 0;
+
+            // 조회수 기준
             if (Objects.equals(value, "view_count")) {
                 dateCount = queryFactory
                         .select(post.viewCount.sum())
                         .from(post)
                         .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
                         .fetchFirst();
-            } else if (Objects.equals(value, "like_count")) {
+            }
+
+            // 좋아요 기준
+            else if (Objects.equals(value, "like_count")) {
                 dateCount = queryFactory
                         .select(post.likeCount.sum())
                         .from(post)
                         .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
                         .fetchFirst();
-            } else if (Objects.equals(value, "share_count")) {
+            }
+
+            // 공유수 기준
+            else if (Objects.equals(value, "share_count")) {
                 dateCount = queryFactory
                         .select(post.shareCount.sum())
                         .from(post)
                         .where(post.createdAt.between(dateTime.getKey(), dateTime.getValue()))
                         .fetchFirst();
-            } else {
+            }
+
+            // 게시글 수 기준
+            else {
                 dateCount = Math.toIntExact(queryFactory
                         .select(post.count())
                         .from(post)
@@ -49,6 +60,7 @@ public class StatisticsRepositoryImpl implements StatisticsRepositoryCustom {
                         .fetchFirst());
             }
 
+            // count 값 더하기
             statisticsResponseDtoList.add(StatisticsResponseDto.builder()
                     .time(dateTime.getKey())
                     .count(dateCount == null ? 0 : dateCount)

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/service/StatisticsService.java
@@ -8,35 +8,72 @@ import com.example.socialmediafeed.domain.statistics.repository.StatisticsReposi
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class StatisticsService {
 
-    private final PostRepository postRepository;
     private final StatisticsRepository statisticsRepository;
 
     /**
      * 통계 결과를 반환하는 메서드
+     *
      * @return List<StatisticsResponseDto.
      */
-    public List<StatisticsResponseDto> getStatistics(){
-
-        // 1. 모든 글에 대해서 하루 단위로 조회하기
-        // hashtag : 일단 이 부분 제외하기
-        // start : 일단 이 부분 제외하기
-        // end : 일단 이 부분 제외하기
-        // count : like_count 기준으로 조회하기(2, 3번은 이 부분을 바꿀 예정)
-        // 예상되는 결과 => {"2023-10-01" : 9, "2023-10-02" : 10, "2023-10-03" : 10}
-        // Post에서 조회하자. 2023-10-29기준으로
-        List<StatisticsResponseDto> statisticsResponseDtoList = statisticsRepository.DateLikeCount();
+    public List<StatisticsResponseDto> getStatistics(String hashtag, String start, String end, String type, String value) {
+        // type는 date또는 hour이 올 수 있다.
+        Map<LocalDateTime, LocalDateTime> dateTimeMap = dateTimeList(hashtag, start, end, type);
+        List<StatisticsResponseDto> statisticsResponseDtoList = statisticsRepository.getStatistics(hashtag, dateTimeMap, value);
         return statisticsResponseDtoList;
     }
 
+    public Map<LocalDateTime, LocalDateTime> dateTimeList(String hashtag, String start, String end, String type) {
+
+        Map<LocalDateTime, LocalDateTime> unitDateTimeList = new HashMap<>();
+
+        // 날짜 구간 설정
+        LocalDate startDateTime = LocalDate.now().minusDays(7);
+        LocalDate endDateTime = LocalDate.now().atTime(LocalTime.MAX).toLocalDate();
+        if (start != null) {
+            startDateTime = LocalDate.parse(start, DateTimeFormatter.ISO_DATE);
+        }
+        if (end != null) {
+            endDateTime = LocalDate.parse(end, DateTimeFormatter.ISO_DATE);
+        }
+
+        // 날짜별 시작 시간과 종료 시간을 LocalDateTime으로
+        List<LocalDate> localDateList = getDatesBetweenTwoDates(startDateTime, endDateTime);
+        for (LocalDate date : localDateList) {
+            if (Objects.equals(type, "date")) {
+                unitDateTimeList.put(date.atStartOfDay(), date.atTime(LocalTime.MAX));
+            } else if (Objects.equals(type, "hour")) {
+                LocalDateTime st = date.atStartOfDay();
+                LocalDateTime fn = st.plusHours(1).minusNanos(1);
+                for (int i = 0; i < 24; i++) {
+                    unitDateTimeList.put(st.plusHours(i), fn.plusHours(i));
+                }
+            }
+        }
+
+        // 날짜별
+        return unitDateTimeList;
+    }
+
+    private static List<LocalDate> getDatesBetweenTwoDates(LocalDate startDate, LocalDate endDate) {
+        List<LocalDate> getDatesBetweenTwoDates = startDate.datesUntil(endDate).collect(Collectors.toList());
+        getDatesBetweenTwoDates.add(endDate);
+        return getDatesBetweenTwoDates;
+    }
 
 }
 

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/service/StatisticsService.java
@@ -25,12 +25,18 @@ public class StatisticsService {
      * @return List<StatisticsResponseDto.
      */
     public List<StatisticsResponseDto> getStatistics(){
-        // todo : Request Parameter 기준으로 StatisticsResponseDto 반환하도록 변경(현재는 dummy data형식)
-        StatisticsResponseDto statisticsResponseDto = StatisticsResponseDto.builder().time(LocalDateTime.now()).count(1).build();
-        List<StatisticsResponseDto> statisticsResponseDtoList = new ArrayList<>();
-        statisticsResponseDtoList.add(statisticsResponseDto);
+
+        // 1. 모든 글에 대해서 하루 단위로 조회하기
+        // hashtag : 일단 이 부분 제외하기
+        // start : 일단 이 부분 제외하기
+        // end : 일단 이 부분 제외하기
+        // count : like_count 기준으로 조회하기(2, 3번은 이 부분을 바꿀 예정)
+        // 예상되는 결과 => {"2023-10-01" : 9, "2023-10-02" : 10, "2023-10-03" : 10}
+        // Post에서 조회하자. 2023-10-29기준으로
+        List<StatisticsResponseDto> statisticsResponseDtoList = statisticsRepository.DateLikeCount();
         return statisticsResponseDtoList;
     }
 
 
 }
+

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/service/StatisticsService.java
@@ -3,6 +3,8 @@ package com.example.socialmediafeed.domain.statistics.service;
 import com.example.socialmediafeed.domain.post.entity.Post;
 import com.example.socialmediafeed.domain.post.repository.PostRepository;
 import com.example.socialmediafeed.domain.statistics.dto.StatisticsResponseDto;
+import com.example.socialmediafeed.domain.statistics.repository.StatisticsRepository;
+import com.example.socialmediafeed.domain.statistics.repository.StatisticsRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +18,7 @@ import java.util.List;
 public class StatisticsService {
 
     private final PostRepository postRepository;
+    private final StatisticsRepository statisticsRepository;
 
     /**
      * 통계 결과를 반환하는 메서드

--- a/src/main/java/com/example/socialmediafeed/domain/statistics/service/StatisticsService.java
+++ b/src/main/java/com/example/socialmediafeed/domain/statistics/service/StatisticsService.java
@@ -51,7 +51,6 @@ public class StatisticsService {
      * @return Map<LocalDateTime, LocalDateTime>
      */
     public Map<LocalDateTime, LocalDateTime> dateTimeMap(String hashtag, String start, String end, String type) {
-        // todo : hashtag 기준 검색도 구현하기
 
         // == 날짜 목록 반환 == //
         List<LocalDate> DateTimeList = getDatesBetweenTwoDates(start, end, type);

--- a/src/main/java/com/example/socialmediafeed/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/example/socialmediafeed/global/error/exception/ErrorCode.java
@@ -19,7 +19,10 @@ public enum ErrorCode {
 
     // Coupon
     COUPON_ALREADY_USE(400, "CO001", "Coupon was already used"),
-    COUPON_EXPIRE(400, "CO002", "Coupon was already expired")
+    COUPON_EXPIRE(400, "CO002", "Coupon was already expired"),
+
+    // Statistics
+    START_END_NOT_VALID(400, "S0001", "start date or end date is not valid")
     ;
 
     private final String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,17 +1,11 @@
 spring:
-  datasource:
-    url: jdbc:h2:tcp://localhost/~/wanted1
-    username: sa
-    password: sa
-    driver-class-name: org.h2.Driver
-
   jpa:
-    hibernate:
-      ddl-auto: create
     properties:
       hibernate:
         show_sql: true
-        format_sql: true
+  h2:
+    console:
+      enabled: true
 
 jwt:
   header: Authorization

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,17 @@
 spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/wanted1
+    username: sa
+    password: sa
+    driver-class-name: org.h2.Driver
+
   jpa:
+    hibernate:
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true
-  h2:
-    console:
-        enabled: true
+        format_sql: true
 
 jwt:
   header: Authorization


### PR DESCRIPTION
## Summary
- 통계 부분을 구현하였습니다.
- 현재 코드에서 Hashtag - PostHashtag - Post 쪽 연관관계가 설정되지 않아 Hashtag를 기준으로는 검색기능이 작동하지 않습니다. 이 부분은 코드 업데이트 되면 구현할 예정입니다.
- 마찬가지로, 해시태그 default값이 user의 해시태그 기반인데 JWT 부분 코드가 merge 되지 않아 이 부분은 아직 구현하지 못했습니다.

## To reviewers
- 전체적인 코드에서 리팩토링이 필요하다고 생각되는 부분이 있으면 말씀해주세요! 추가하겠습니다.

## TIL
- [QueryDsl 김가영 정리](https://gabang2.notion.site/QueryDsl-43b0901997104bb89c96bcc4d9da78ed?pvs=4)