### PR TITLE
Feat #41 : 게시물 상세(API) 작성

### DIFF
--- a/src/main/java/com/example/socialmediafeed/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/socialmediafeed/domain/post/controller/PostController.java
@@ -1,16 +1,14 @@
 package com.example.socialmediafeed.domain.post.controller;
 
 import com.example.socialmediafeed.domain.post.entity.Post;
-import com.example.socialmediafeed.domain.post.service.PostService;
+import com.example.socialmediafeed.domain.post.service.PostReadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -18,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PostController {
 
-    private final PostService postService;
+    private final PostReadService postReadService;
 
     @GetMapping("")
     public ResponseEntity<Page<Post>> getPosts(
@@ -28,9 +26,15 @@ public class PostController {
             @RequestParam(defaultValue = "createdAt") String sortBy,
             @RequestParam(defaultValue = "desc") String sortOrder
     ) {
-        Page<Post> postsList = postService.getPosts(hashtag, page, page_count, sortBy, sortOrder);
+        Page<Post> postsList = postReadService.getPosts(hashtag, page, page_count, sortBy, sortOrder);
 
         return ResponseEntity.ok(postsList);
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<Post> getPost(@PathVariable Long postId) {
+        Post post = postReadService.getPostById(postId);
+        return ResponseEntity.ok(post);
     }
 
 }

--- a/src/main/java/com/example/socialmediafeed/domain/post/entity/Post.java
+++ b/src/main/java/com/example/socialmediafeed/domain/post/entity/Post.java
@@ -64,4 +64,7 @@ public class Post {
         this.shareCount = shareCount;
     }
 
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
 }

--- a/src/main/java/com/example/socialmediafeed/domain/post/service/PostReadService.java
+++ b/src/main/java/com/example/socialmediafeed/domain/post/service/PostReadService.java
@@ -9,11 +9,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
 import java.util.List;
@@ -22,7 +19,7 @@ import static com.example.socialmediafeed.domain.post.entity.QPost.post;
 
 @RequiredArgsConstructor
 @Service
-public class PostService {
+public class PostReadService {
 
     private final EntityManager entityManager;
     private final PostRepository postRepository;
@@ -53,11 +50,21 @@ public class PostService {
         int endIndex = Math.min((startIndex + pageable.getPageSize()), results.size());
 
         if (startIndex > results.size() || startIndex < 0) {
-            // Handle the case where startIndex is out of bounds
             return new PageImpl<>(Collections.emptyList(), pageable, 0);
         }
 
         Page<Post> pageResults = new PageImpl<>(results.subList(startIndex, endIndex), pageable, results.size());
 
         return pageResults;
+    }
+
+    @Transactional
+    public Post getPostById(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시물을 찾을 수 없습니다."));
+
+        post.incrementViewCount();
+        Post updatedPost = postRepository.save(post);
+        return updatedPost;
+    }
 }

--- a/src/test/java/com/example/socialmediafeed/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/example/socialmediafeed/domain/post/controller/PostControllerTest.java
@@ -1,16 +1,15 @@
 package com.example.socialmediafeed.domain.post.controller;
 
 import com.example.socialmediafeed.IntegrationTest;
-import com.example.socialmediafeed.SocialMediaFeedApplication;
+import com.example.socialmediafeed.domain.post.entity.Post;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.util.Map;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -52,6 +51,40 @@ class PostControllerTest extends IntegrationTest {
                 .andReturn();
 
         status = mvcResult.getResponse().getStatus();
-        assertEquals(204, status);
+        assertEquals(200, status);
+    }
+
+    @Test
+    public void testGetPostById() throws Exception {
+        Long postId = 20L;
+        Logger logger = Logger.getLogger(getClass().getName());
+
+        MvcResult mvcResult = mvc.perform(MockMvcRequestBuilders.get("/posts/" + postId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andReturn();
+
+        int status = mvcResult.getResponse().getStatus();
+        assertEquals(200, status);
+
+        String content = mvcResult.getResponse().getContentAsString();
+        Post post = objectMapper.readValue(content, Post.class);
+        int initialViewCount = post.getViewCount();
+
+        logger.info("Initial viewCount: " + initialViewCount);
+
+        for (int i = 0; i < 5; i++) {
+            mvcResult = mvc.perform(MockMvcRequestBuilders.get("/posts/" + postId)
+                            .contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andReturn();
+
+            status = mvcResult.getResponse().getStatus();
+            assertEquals(200, status);
+
+            content = mvcResult.getResponse().getContentAsString();
+            post = objectMapper.readValue(content, Post.class);
+            int updatedViewCount = post.getViewCount();
+
+            logger.info("Updated viewCount: " + updatedViewCount);
+        }
     }
 }


### PR DESCRIPTION
- /posts/{postId} 엔드포인트로 게시물 상세페이지 접근 & 게시물 조회수 1 증가
- PostService를 PostReadService로 이름 변경 (post는 조회(read)/상호작용(좋아요,공유)별로 service 별도 작성 예정)
- 게시물 상세 test 추가 : 엔드포인트 이동 시 조회수(viewCount) 증가 (최초 이동 시 조회수 1증가 -> 5번 반복하여 엔드포인트 접근하여 추가로 5증가 : 조회수 총 6 증가 확인)