### PR TITLE
Feat #53 : 게시물 공유(API) 작성

### DIFF
--- a/src/main/java/com/example/socialmediafeed/domain/post/controller/PostController.java
+++ b/src/main/java/com/example/socialmediafeed/domain/post/controller/PostController.java
@@ -44,4 +44,10 @@ public class PostController {
         postInteractionService.likePost(postId);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/{postId}/shares")
+    public ResponseEntity<?> sharePost(@PathVariable Long postId) {
+        postInteractionService.sharePost(postId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/socialmediafeed/domain/post/entity/Post.java
+++ b/src/main/java/com/example/socialmediafeed/domain/post/entity/Post.java
@@ -75,4 +75,8 @@ public class Post {
     public void incrementLikeCount() {
         this.likeCount++;
     }
+
+    public void incrementShareCount() {
+        this.shareCount++;
+    }
 }

--- a/src/main/java/com/example/socialmediafeed/domain/post/service/PostInteractionService.java
+++ b/src/main/java/com/example/socialmediafeed/domain/post/service/PostInteractionService.java
@@ -23,4 +23,15 @@ public class PostInteractionService {
 
         snsFeedService.searchSns();
     }
+
+    @Transactional
+    public void sharePost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시물을 찾을 수 없습니다."));
+
+        post.incrementShareCount();
+
+        snsFeedService.searchSns();
+    }
+
 }

--- a/src/test/java/com/example/socialmediafeed/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/example/socialmediafeed/domain/post/controller/PostControllerTest.java
@@ -91,4 +91,23 @@ class PostControllerTest extends IntegrationTest {
 
         logger.info("Initial likeCount: " + initialLikeCount);
     }
+
+    @Test
+    void countSharesOnPost() throws Exception {
+        Long postId = 10L;
+        Logger logger = Logger.getLogger(getClass().getName());
+
+        MvcResult mvcResult = mvc.perform(MockMvcRequestBuilders.get("/posts/" + postId + "/shares")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andReturn();
+
+        int status = mvcResult.getResponse().getStatus();
+        assertEquals(200, status);
+
+        String content = mvcResult.getResponse().getContentAsString();
+        Post post = objectMapper.readValue(content, Post.class);
+        int initialShareCount = post.getShareCount();
+
+        logger.info("Initial shareCount: " + initialShareCount);
+    }
 }


### PR DESCRIPTION
- 게시물 공유 엔드포인트 이동 시, 해당 게시물의 공유 수(shareCount) 1 증가
- 각 sns 호출은 전송이 성공했다는 로그 출력으로 구현